### PR TITLE
Add @damacus, @tas50, @xorima and @bennyvasquez to the Test Kitchen board

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -1,6 +1,45 @@
 {
   "organization": "Test Kitchen",
-  "board": [],
+  "board": [
+    "damacus",
+    "tas50",
+    "bennyvasquez",
+    "xorima"
+  ],
   "bots": [],
-  "maintainers": []
+  "maintainers": [
+    "RoboticCheese",
+    "tas50",
+    "cl-lab-k",
+    "StylusEater",
+    "devopsdina",
+    "fifthecho",
+    "gregf",
+    "jeffreycoe",
+    "someara",
+    "proffalken",
+    "mbrukman",
+    "erjohnso",
+    "Temikus",
+    "jjasghar",
+    "paulrossman",
+    "fnichol",
+    "smurawski",
+    "tecracer-theinen",
+    "andrewjamesbrown",
+    "ramereth",
+    "mwrock",
+    "clintoncwolfe",
+    "lamont-granquist",
+    "robbkidd",
+    "marcparadise",
+    "tyler-ball",
+    "stuartpreston",
+    "vexx32",
+    "martinb3",
+    "kisoku",
+    "gep13",
+    "chasebolt",
+    "bnwoods"
+  ]
 }


### PR DESCRIPTION
# Description

Adding, Tim, benny, and Jason to the board. 
Adding all current maintainers that are in single person groups to a single maintainers group. 
Adding external contributors to maintainers.
